### PR TITLE
Inject bound event before advise nodes when not yet connected

### DIFF
--- a/runtime/driver/src/main/java/io/aklivity/k3po/runtime/driver/internal/behavior/visitor/InjectEventsVisitor.java
+++ b/runtime/driver/src/main/java/io/aklivity/k3po/runtime/driver/internal/behavior/visitor/InjectEventsVisitor.java
@@ -573,7 +573,17 @@ public class InjectEventsVisitor implements AstNode.Visitor<AstScriptNode, State
 
     @Override
     public AstScriptNode visit(AstReadAdviseNode node, State state) {
-        injectBoundIfBeforeConnected(node, state);
+        switch (state.connectivityState) {
+        case NONE:
+        case OPENED:
+            AstBoundNode boundNode = new AstBoundNode();
+            boundNode.setRegionInfo(node.getRegionInfo());
+            boundNode.accept(this, state);
+            break;
+        default:
+            break;
+        }
+
         switch (state.connectivityState) {
         case BOUND:
         case CONNECTED:
@@ -587,7 +597,17 @@ public class InjectEventsVisitor implements AstNode.Visitor<AstScriptNode, State
 
     @Override
     public AstScriptNode visit(AstWriteAdviseNode node, State state) {
-        injectBoundIfBeforeConnected(node, state);
+        switch (state.connectivityState) {
+        case NONE:
+        case OPENED:
+            AstBoundNode boundNode = new AstBoundNode();
+            boundNode.setRegionInfo(node.getRegionInfo());
+            boundNode.accept(this, state);
+            break;
+        default:
+            break;
+        }
+
         switch (state.connectivityState) {
         case BOUND:
         case CONNECTED:
@@ -601,7 +621,17 @@ public class InjectEventsVisitor implements AstNode.Visitor<AstScriptNode, State
 
     @Override
     public AstScriptNode visit(AstReadAdvisedNode node, State state) {
-        injectBoundIfBeforeConnected(node, state);
+        switch (state.connectivityState) {
+        case NONE:
+        case OPENED:
+            AstBoundNode boundNode = new AstBoundNode();
+            boundNode.setRegionInfo(node.getRegionInfo());
+            boundNode.accept(this, state);
+            break;
+        default:
+            break;
+        }
+
         switch (state.connectivityState) {
         case BOUND:
         case CONNECTED:
@@ -615,19 +645,6 @@ public class InjectEventsVisitor implements AstNode.Visitor<AstScriptNode, State
 
     @Override
     public AstScriptNode visit(AstWriteAdvisedNode node, State state) {
-        injectBoundIfBeforeConnected(node, state);
-        switch (state.connectivityState) {
-        case BOUND:
-        case CONNECTED:
-            state.streamables.add(node);
-            break;
-        default:
-            throw new IllegalStateException(String.format("Unexpected \"%s\" before connected", node));
-        }
-        return null;
-    }
-
-    private void injectBoundIfBeforeConnected(AstStreamableNode node, State state) {
         switch (state.connectivityState) {
         case NONE:
         case OPENED:
@@ -638,6 +655,16 @@ public class InjectEventsVisitor implements AstNode.Visitor<AstScriptNode, State
         default:
             break;
         }
+
+        switch (state.connectivityState) {
+        case BOUND:
+        case CONNECTED:
+            state.streamables.add(node);
+            break;
+        default:
+            throw new IllegalStateException(String.format("Unexpected \"%s\" before connected", node));
+        }
+        return null;
     }
 
     @Override

--- a/runtime/driver/src/main/java/io/aklivity/k3po/runtime/driver/internal/behavior/visitor/InjectEventsVisitor.java
+++ b/runtime/driver/src/main/java/io/aklivity/k3po/runtime/driver/internal/behavior/visitor/InjectEventsVisitor.java
@@ -573,54 +573,71 @@ public class InjectEventsVisitor implements AstNode.Visitor<AstScriptNode, State
 
     @Override
     public AstScriptNode visit(AstReadAdviseNode node, State state) {
+        injectBoundIfBeforeConnected(node, state);
         switch (state.connectivityState) {
-        case NONE:
+        case BOUND:
         case CONNECTED:
+            state.streamables.add(node);
             break;
         default:
             throw new IllegalStateException(String.format("Unexpected \"%s\" before connected", node));
         }
-        state.streamables.add(node);
         return null;
     }
 
     @Override
     public AstScriptNode visit(AstWriteAdviseNode node, State state) {
+        injectBoundIfBeforeConnected(node, state);
         switch (state.connectivityState) {
-        case NONE:
+        case BOUND:
         case CONNECTED:
+            state.streamables.add(node);
             break;
         default:
             throw new IllegalStateException(String.format("Unexpected \"%s\" before connected", node));
         }
-        state.streamables.add(node);
         return null;
     }
 
     @Override
     public AstScriptNode visit(AstReadAdvisedNode node, State state) {
+        injectBoundIfBeforeConnected(node, state);
         switch (state.connectivityState) {
-        case NONE:
+        case BOUND:
         case CONNECTED:
+            state.streamables.add(node);
             break;
         default:
             throw new IllegalStateException(String.format("Unexpected \"%s\" before connected", node));
         }
-        state.streamables.add(node);
         return null;
     }
 
     @Override
     public AstScriptNode visit(AstWriteAdvisedNode node, State state) {
+        injectBoundIfBeforeConnected(node, state);
         switch (state.connectivityState) {
-        case NONE:
+        case BOUND:
         case CONNECTED:
+            state.streamables.add(node);
             break;
         default:
             throw new IllegalStateException(String.format("Unexpected \"%s\" before connected", node));
         }
-        state.streamables.add(node);
         return null;
+    }
+
+    private void injectBoundIfBeforeConnected(AstStreamableNode node, State state) {
+        switch (state.connectivityState) {
+        case NONE:
+        case OPENED:
+            AstBoundNode boundNode = new AstBoundNode();
+            boundNode.setRegionInfo(node.getRegionInfo());
+            boundNode.accept(this, state);
+            break;
+        default:
+            break;
+        }
     }
 
     @Override

--- a/runtime/driver/src/test/java/io/aklivity/k3po/runtime/driver/internal/behavior/visitor/InjectEventsVisitorTest.java
+++ b/runtime/driver/src/test/java/io/aklivity/k3po/runtime/driver/internal/behavior/visitor/InjectEventsVisitorTest.java
@@ -21,7 +21,12 @@ import org.junit.Test;
 
 import io.aklivity.k3po.runtime.driver.internal.behavior.parser.Parser;
 import io.aklivity.k3po.runtime.driver.internal.behavior.visitor.InjectEventsVisitor;
+import io.aklivity.k3po.runtime.lang.internal.ast.AstConnectedNode;
+import io.aklivity.k3po.runtime.lang.internal.ast.AstReadAdviseNode;
+import io.aklivity.k3po.runtime.lang.internal.ast.AstReadAdvisedNode;
 import io.aklivity.k3po.runtime.lang.internal.ast.AstScriptNode;
+import io.aklivity.k3po.runtime.lang.internal.ast.AstWriteAdviseNode;
+import io.aklivity.k3po.runtime.lang.internal.ast.AstWriteAdvisedNode;
 import io.aklivity.k3po.runtime.lang.internal.ast.builder.AstScriptNodeBuilder;
 import io.aklivity.k3po.runtime.lang.internal.parser.ScriptParseException;
 import io.aklivity.k3po.runtime.lang.internal.parser.ScriptParser;
@@ -327,7 +332,7 @@ public class InjectEventsVisitorTest {
 
         String script =
             "# tcp.client.connect-then-close\n" +
-            "connect tcp://localhost:7788\n" +
+            "connect 'tcp://localhost:7788'\n" +
             "connected\n" +
             "close\n" +
             "closed\n" +
@@ -336,5 +341,175 @@ public class InjectEventsVisitorTest {
 
         ScriptParser parser = new Parser();
         parser.parse(script);
+    }
+
+    @Test
+    public void shouldInjectOpenedAndBoundBeforeReadAdviseAndConnected()
+        throws Exception {
+
+        // @formatter:off
+        AstScriptNode expectedScriptNode = new AstScriptNodeBuilder()
+            .addConnectStream()
+                .addOpenedEvent()
+                    .done()
+                .addBoundEvent()
+                    .done()
+                .done()
+            .done();
+        AstReadAdviseNode expectedAdvise = new AstReadAdviseNode();
+        expectedScriptNode.getStreams().get(0).getStreamables().add(expectedAdvise);
+        AstConnectedNode expectedConnected = new AstConnectedNode();
+        expectedScriptNode.getStreams().get(0).getStreamables().add(expectedConnected);
+
+        AstScriptNode inputScriptNode = new AstScriptNodeBuilder()
+            .addConnectStream()
+                .done()
+            .done();
+        AstReadAdviseNode inputAdvise = new AstReadAdviseNode();
+        inputScriptNode.getStreams().get(0).getStreamables().add(inputAdvise);
+        AstConnectedNode inputConnected = new AstConnectedNode();
+        inputScriptNode.getStreams().get(0).getStreamables().add(inputConnected);
+        // @formatter:on
+
+        InjectEventsVisitor injectEvents = new InjectEventsVisitor();
+        AstScriptNode actualScriptNode = inputScriptNode.accept(injectEvents, new InjectEventsVisitor.State());
+
+        assertEquals(expectedScriptNode, actualScriptNode);
+    }
+
+    @Test
+    public void shouldInjectOpenedAndBoundBeforeReadAdvisedAndConnected()
+        throws Exception {
+
+        // @formatter:off
+        AstScriptNode expectedScriptNode = new AstScriptNodeBuilder()
+            .addConnectStream()
+                .addOpenedEvent()
+                    .done()
+                .addBoundEvent()
+                    .done()
+                .done()
+            .done();
+        AstReadAdvisedNode expectedAdvised = new AstReadAdvisedNode();
+        expectedScriptNode.getStreams().get(0).getStreamables().add(expectedAdvised);
+        AstConnectedNode expectedConnected = new AstConnectedNode();
+        expectedScriptNode.getStreams().get(0).getStreamables().add(expectedConnected);
+
+        AstScriptNode inputScriptNode = new AstScriptNodeBuilder()
+            .addConnectStream()
+                .done()
+            .done();
+        AstReadAdvisedNode inputAdvised = new AstReadAdvisedNode();
+        inputScriptNode.getStreams().get(0).getStreamables().add(inputAdvised);
+        AstConnectedNode inputConnected = new AstConnectedNode();
+        inputScriptNode.getStreams().get(0).getStreamables().add(inputConnected);
+        // @formatter:on
+
+        InjectEventsVisitor injectEvents = new InjectEventsVisitor();
+        AstScriptNode actualScriptNode = inputScriptNode.accept(injectEvents, new InjectEventsVisitor.State());
+
+        assertEquals(expectedScriptNode, actualScriptNode);
+    }
+
+    @Test
+    public void shouldInjectOpenedAndBoundBeforeWriteAdviseAndConnected()
+        throws Exception {
+
+        // @formatter:off
+        AstScriptNode expectedScriptNode = new AstScriptNodeBuilder()
+            .addConnectStream()
+                .addOpenedEvent()
+                    .done()
+                .addBoundEvent()
+                    .done()
+                .done()
+            .done();
+        AstWriteAdviseNode expectedAdvise = new AstWriteAdviseNode();
+        expectedScriptNode.getStreams().get(0).getStreamables().add(expectedAdvise);
+        AstConnectedNode expectedConnected = new AstConnectedNode();
+        expectedScriptNode.getStreams().get(0).getStreamables().add(expectedConnected);
+
+        AstScriptNode inputScriptNode = new AstScriptNodeBuilder()
+            .addConnectStream()
+                .done()
+            .done();
+        AstWriteAdviseNode inputAdvise = new AstWriteAdviseNode();
+        inputScriptNode.getStreams().get(0).getStreamables().add(inputAdvise);
+        AstConnectedNode inputConnected = new AstConnectedNode();
+        inputScriptNode.getStreams().get(0).getStreamables().add(inputConnected);
+        // @formatter:on
+
+        InjectEventsVisitor injectEvents = new InjectEventsVisitor();
+        AstScriptNode actualScriptNode = inputScriptNode.accept(injectEvents, new InjectEventsVisitor.State());
+
+        assertEquals(expectedScriptNode, actualScriptNode);
+    }
+
+    @Test
+    public void shouldInjectOpenedAndBoundBeforeWriteAdvisedAndConnected()
+        throws Exception {
+
+        // @formatter:off
+        AstScriptNode expectedScriptNode = new AstScriptNodeBuilder()
+            .addConnectStream()
+                .addOpenedEvent()
+                    .done()
+                .addBoundEvent()
+                    .done()
+                .done()
+            .done();
+        AstWriteAdvisedNode expectedAdvised = new AstWriteAdvisedNode();
+        expectedScriptNode.getStreams().get(0).getStreamables().add(expectedAdvised);
+        AstConnectedNode expectedConnected = new AstConnectedNode();
+        expectedScriptNode.getStreams().get(0).getStreamables().add(expectedConnected);
+
+        AstScriptNode inputScriptNode = new AstScriptNodeBuilder()
+            .addConnectStream()
+                .done()
+            .done();
+        AstWriteAdvisedNode inputAdvised = new AstWriteAdvisedNode();
+        inputScriptNode.getStreams().get(0).getStreamables().add(inputAdvised);
+        AstConnectedNode inputConnected = new AstConnectedNode();
+        inputScriptNode.getStreams().get(0).getStreamables().add(inputConnected);
+        // @formatter:on
+
+        InjectEventsVisitor injectEvents = new InjectEventsVisitor();
+        AstScriptNode actualScriptNode = inputScriptNode.accept(injectEvents, new InjectEventsVisitor.State());
+
+        assertEquals(expectedScriptNode, actualScriptNode);
+    }
+
+    @Test
+    public void shouldKeepReadAdviseAfterConnectedUnchanged()
+        throws Exception {
+
+        // @formatter:off
+        AstScriptNode expectedScriptNode = new AstScriptNodeBuilder()
+            .addConnectStream()
+                .addOpenedEvent()
+                    .done()
+                .addBoundEvent()
+                    .done()
+                .addConnectedEvent()
+                    .done()
+                .done()
+            .done();
+        AstReadAdviseNode expectedAdvise = new AstReadAdviseNode();
+        expectedScriptNode.getStreams().get(0).getStreamables().add(expectedAdvise);
+
+        AstScriptNode inputScriptNode = new AstScriptNodeBuilder()
+            .addConnectStream()
+                .addConnectedEvent()
+                    .done()
+                .done()
+            .done();
+        AstReadAdviseNode inputAdvise = new AstReadAdviseNode();
+        inputScriptNode.getStreams().get(0).getStreamables().add(inputAdvise);
+        // @formatter:on
+
+        InjectEventsVisitor injectEvents = new InjectEventsVisitor();
+        AstScriptNode actualScriptNode = inputScriptNode.accept(injectEvents, new InjectEventsVisitor.State());
+
+        assertEquals(expectedScriptNode, actualScriptNode);
     }
 }


### PR DESCRIPTION
## Summary
This change fixes the event injection logic in `InjectEventsVisitor` to properly inject `AstBoundNode` events before advise-related nodes (`AstReadAdviseNode`, `AstWriteAdviseNode`, `AstReadAdvisedNode`, `AstWriteAdvisedNode`) when they appear before the connected state.

## Key Changes
- **Modified `InjectEventsVisitor.java`**:
  - Updated `visit()` methods for all four advise node types to call a new `injectBoundIfBeforeConnected()` helper method
  - Changed the connectivity state validation from accepting `NONE` state to accepting `BOUND` state, ensuring bound events are injected first
  - Added new `injectBoundIfBeforeConnected()` method that injects a `AstBoundNode` when advise nodes appear in `NONE` or `OPENED` states
  - Moved `state.streamables.add(node)` to occur after state validation, ensuring proper ordering

- **Updated `InjectEventsVisitorTest.java`**:
  - Added imports for the new AST node types being tested
  - Fixed existing test to use quoted URL syntax (`'tcp://localhost:7788'`)
  - Added four new test cases validating that opened and bound events are injected before various advise node combinations with connected events
  - Added one test case verifying that advise nodes appearing after connected events remain unchanged

## Implementation Details
The fix ensures that when advise nodes appear before a stream is connected, the visitor automatically injects the required `opened` and `bound` events in the correct sequence. This maintains the proper event ordering required by the K3PO runtime while allowing test scripts to omit these implicit events.

Fixes #9 