### PR TITLE
Add awaitPrepared() method to K3poRule for concurrent script readiness

### DIFF
--- a/runtime/control-junit/src/main/java/io/aklivity/k3po/runtime/junit/rules/K3poRule.java
+++ b/runtime/control-junit/src/main/java/io/aklivity/k3po/runtime/junit/rules/K3poRule.java
@@ -203,6 +203,29 @@ public class K3poRule extends Verifier {
     }
 
     /**
+     * Blocking call to await until k3po has acked PREPARED via the control protocol, i.e. all accepts are open and any
+     * k3po-owned shared resources have been allocated.  Unlike {@link #start()} and {@link #finish()}, this method does not
+     * drive the script forward; it only observes the PREPARED state produced by the implicit start inside {@link #finish()}.
+     * <p>
+     * This is intended to be called concurrently from a non-test thread (e.g. a watcher thread spawned by a consuming rule)
+     * that needs to block until k3po is ready before driving an external runtime.  It is safe to call more than once; once
+     * PREPARED has been acked it returns immediately.
+     * <p>
+     * Declares no checked exception so it can be supplied directly as a {@link Runnable} (e.g.
+     * {@code engineRule.beforeStart(k3po::awaitPrepared)}); any failure while preparing the script is rethrown unchecked.
+     */
+    public void awaitPrepared() {
+        try {
+            latch.awaitPrepared();
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(ex);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    /**
      * Blocking call to await for the K3po threads to stop executing.  If the connects have not already been initiated via the
      * start() method, they will be implicitly called.
      * @throws Exception if an error has occurred in the execution of the tests.


### PR DESCRIPTION
## Summary
Added a new `awaitPrepared()` method to `K3poRule` that allows non-test threads to block until k3po has acknowledged the PREPARED state via the control protocol, without driving the script forward.

## Key Changes
- **New `awaitPrepared()` method**: Provides a blocking call that waits for k3po to acknowledge PREPARED state (all accepts open and shared resources allocated)
- **Non-blocking for script execution**: Unlike `start()` and `finish()`, this method only observes the PREPARED state without advancing the script
- **Concurrent-safe**: Designed to be called from non-test threads (e.g., watcher threads) that need to synchronize with k3po readiness before driving external runtimes
- **Idempotent**: Safe to call multiple times; returns immediately once PREPARED has been acked
- **Exception handling**: Converts checked exceptions to unchecked `RuntimeException` to allow usage as a `Runnable` (e.g., `engineRule.beforeStart(k3po::awaitPrepared)`)

## Implementation Details
- Delegates to `latch.awaitPrepared()` for the actual synchronization logic
- Handles `InterruptedException` by restoring the interrupt flag and rethrowing as `RuntimeException`
- Wraps any other exceptions as `RuntimeException` for compatibility with functional interfaces

https://claude.ai/code/session_01XcNeWBUJAA87NSf9R4KdVT