### PR TITLE
Support defer startable hook

### DIFF
--- a/runtime/control-junit/src/main/java/io/aklivity/k3po/runtime/junit/internal/Latch.java
+++ b/runtime/control-junit/src/main/java/io/aklivity/k3po/runtime/junit/internal/Latch.java
@@ -30,15 +30,22 @@ public class Latch {
     private final CountDownLatch startable;
     private final CountDownLatch finished;
     private volatile Thread testThread;
-    
-    private final AtomicBoolean testThreadInterrupted = new AtomicBoolean(false); 
+    private volatile CountDownLatch deferred;
+
+    private final AtomicBoolean testThreadInterrupted = new AtomicBoolean(false);
 
     public Latch() {
         state = State.INIT;
 
         prepared = new CountDownLatch(1);
+        deferred = new CountDownLatch(0);
         startable = new CountDownLatch(1);
         finished = new CountDownLatch(1);
+    }
+
+    public Runnable deferStartable() {
+        deferred = new CountDownLatch(1);
+        return deferred::countDown;
     }
 
     public void notifyPrepared() {
@@ -83,6 +90,7 @@ public class Latch {
     }
 
     public void awaitStartable() throws Exception {
+        deferred.await();
         startable.await();
         if (exception != null) {
             throw exception;

--- a/runtime/control-junit/src/main/java/io/aklivity/k3po/runtime/junit/rules/K3poRule.java
+++ b/runtime/control-junit/src/main/java/io/aklivity/k3po/runtime/junit/rules/K3poRule.java
@@ -203,18 +203,21 @@ public class K3poRule extends Verifier {
     }
 
     /**
-     * Blocking call to await until k3po has acked PREPARED via the control protocol, i.e. all accepts are open and any
-     * k3po-owned shared resources have been allocated.  Unlike {@link #start()} and {@link #finish()}, this method does not
-     * drive the script forward; it only observes the PREPARED state produced by the implicit start inside {@link #finish()}.
+     * Installs a gate that holds the script between PREPARED and STARTABLE, then blocks until k3po has acked PREPARED via
+     * the control protocol (all accepts are open and any k3po-owned shared resources have been allocated), and returns a
+     * release {@link Runnable}.  The script will not be driven forward past PREPARED until the returned Runnable is invoked.
      * <p>
-     * This is intended to be called concurrently from a non-test thread (e.g. a watcher thread spawned by a consuming rule)
-     * that needs to block until k3po is ready before driving an external runtime.  It is safe to call more than once; once
-     * PREPARED has been acked it returns immediately.
+     * This is intended to be called from a non-test thread that must both block until k3po is prepared and keep the script
+     * paused afterwards while it performs further setup, releasing the script (by invoking the returned Runnable) only once
+     * that setup is complete.  It thus combines awaiting PREPARED with a one-shot hold on the PREPARED&#8594;STARTABLE
+     * transition.
      * <p>
-     * Declares no checked exception so it can be supplied directly as a {@link Runnable} (e.g.
-     * {@code engineRule.beforeStart(k3po::awaitPrepared)}); any failure while preparing the script is rethrown unchecked.
+     * The gate is installed before awaiting PREPARED so it is always visible to the script runner before it observes the
+     * PREPARED state; this avoids a race where the script could pass an as-yet-uninstalled gate.  Any failure while
+     * preparing the script is rethrown unchecked.
      */
-    public void awaitPrepared() {
+    public Runnable deferStartable() {
+        Runnable release = latch.deferStartable();
         try {
             latch.awaitPrepared();
         } catch (InterruptedException ex) {
@@ -223,6 +226,7 @@ public class K3poRule extends Verifier {
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         }
+        return release;
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds a `K3poRule.deferStartable()` hook that lets a non-test thread both wait for the script to reach `PREPARED` and keep it paused before `STARTABLE` until the caller signals it is ready.

`deferStartable()` installs a one-shot gate, blocks until k3po has acked `PREPARED` (all accepts open, shared resources allocated), and returns a release `Runnable`. The script will not be driven past `PREPARED` until that `Runnable` is invoked. This combines two needs in a single call:

- block until k3po is prepared, and
- keep the script paused afterwards while the caller performs further setup, releasing it only once that setup is complete.

This replaces the earlier `awaitPrepared()` shape (which only observed `PREPARED`) with one that can also gate the `PREPARED → STARTABLE` transition, so a consuming rule can interleave its own initialization between a script's accepts being bound and the script's connects being driven.

## Implementation

- `Latch`: adds a `deferred` gate latch (default already-open `CountDownLatch(0)`, so `awaitStartable()` falls through unless a gate is installed) and `deferStartable()` to install a closed one and return its `countDown`. `awaitStartable()` awaits the gate before `startable`.
- `K3poRule.awaitPrepared()` → `deferStartable()`: installs the gate **before** awaiting `PREPARED`, so it is always visible to the script runner before it observes the `PREPARED` state (avoids a race where the script could pass an as-yet-uninstalled gate), then returns the release `Runnable`.

Default behavior is unchanged for scripts that never call `deferStartable()` — the gate stays open and `awaitStartable()` proceeds exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)