### PR TITLE
Pin Kaazing net dependencies to version 1.1.0.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,22 +90,22 @@
       <dependency>
         <groupId>org.kaazing</groupId>
         <artifactId>net.api</artifactId>
-        <version>[1.1.0.0, 1.2.0.0)</version>
+        <version>1.1.0.9</version>
       </dependency>
       <dependency>
         <groupId>org.kaazing</groupId>
         <artifactId>net.data</artifactId>
-        <version>[1.1.0.0, 1.2.0.0)</version>
+        <version>1.1.0.9</version>
       </dependency>
       <dependency>
         <groupId>org.kaazing</groupId>
         <artifactId>net.tcp</artifactId>
-        <version>[1.1.0.0, 1.2.0.0)</version>
+        <version>1.1.0.9</version>
       </dependency>
       <dependency>
         <groupId>org.kaazing</groupId>
         <artifactId>net.bbosh</artifactId>
-        <version>[1.1.0.0, 1.2.0.0)</version>
+        <version>1.1.0.9</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
## Summary
This change pins the versions of Kaazing net-related dependencies to a specific release version instead of using a version range.

## Key Changes
- Updated `net.api` dependency from version range `[1.1.0.0, 1.2.0.0)` to fixed version `1.1.0.9`
- Updated `net.data` dependency from version range `[1.1.0.0, 1.2.0.0)` to fixed version `1.1.0.9`
- Updated `net.tcp` dependency from version range `[1.1.0.0, 1.2.0.0)` to fixed version `1.1.0.9`
- Updated `net.bbosh` dependency from version range `[1.1.0.0, 1.2.0.0)` to fixed version `1.1.0.9`

## Implementation Details
This change replaces Maven version range specifications with an exact version pin. This ensures consistent and reproducible builds by eliminating the possibility of different patch versions being resolved during dependency resolution. All four Kaazing net dependencies are now locked to the same specific version `1.1.0.9`.

https://claude.ai/code/session_01Br7T7CmnoMLUrtEpF4j9AG